### PR TITLE
Reschedule daily security scan to avoid hitting API rate limit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,7 +97,7 @@ workflows:
   security:
     triggers:
       - schedule:
-          cron: "11 5 * * 1-5"
+          cron: "42 3 * * 1-5"
           filters:
             branches:
               only:
@@ -130,5 +130,3 @@ workflows:
           context:
             - veracode-credentials
             - hmpps-common-vars
-
-


### PR DESCRIPTION
We currently run into API rate limits:
```
2021-10-27T05:13:00.210Z	INFO	Need to update DB
2021-10-27T05:13:00.210Z	INFO	Downloading DB...
2021-10-27T05:13:00.254Z	FATAL	DB error: failed to download vulnerability DB: failed to ⏎
  download vulnerability DB: failed to list releases: GET https://api.github.com/repos/aquasecurity/trivy-db/releases: ⏎
  403 API rate limit exceeded for 3.81.225.69. (But here's the good news: Authenticated requests ⏎
  get a higher rate limit. Check out the documentation for more details.) [rate reset in 9m39s]
```

https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-delius-interventions-event-listener/107/workflows/a41a1703-01a3-410f-9aa6-71d724422cdc/jobs/316

The 10 minute window suggests others are also using this timeslot to run
exactly these tests

So let's do them at 3:42 UTC instead. Selected at random