### PR TITLE
Use the Alpine image to reduce size and fix security

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,22 +7,20 @@ WORKDIR /app
 ADD . .
 RUN ./gradlew assemble -Dorg.gradle.daemon=false
 
-FROM openjdk:16-slim
+FROM adoptopenjdk/openjdk16:alpine-jre
 LABEL maintainer="HMPPS Digital Studio <info@digital.justice.gov.uk>"
 
-ARG BUILD_NUMBER
-ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
-
-RUN apt-get update && \
-    apt-get -y upgrade && \
-    apt-get install -y curl && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk upgrade --no-cache && \
+    apk add --no-cache \
+      curl \
+      tzdata
 
 ENV TZ=Europe/London
 RUN ln -snf "/usr/share/zoneinfo/$TZ" /etc/localtime && echo "$TZ" > /etc/timezone
 
 RUN addgroup --gid 2000 --system appgroup && \
-    adduser --uid 2000 --system appuser --gid 2000
+    adduser --uid 2000 --system appuser && \
+    adduser appuser appgroup
 
 WORKDIR /app
 COPY --from=builder --chown=appuser:appgroup /app/build/libs/hmpps-delius-interventions-event-listener*.jar /app/app.jar
@@ -31,5 +29,8 @@ COPY --from=builder --chown=appuser:appgroup /app/applicationinsights.json /app
 COPY --from=builder --chown=appuser:appgroup /app/applicationinsights.dev.json /app
 
 USER 2000
+
+ARG BUILD_NUMBER
+ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
 
 ENTRYPOINT ["java", "-javaagent:/app/agent.jar", "-jar", "/app/app.jar"]


### PR DESCRIPTION
The current high and critical image OS vulnerabilities are:

```
$ trivy image --severity HIGH,CRITICAL quay.io/hmpps/hmpps-delius-interventions-event-listener
{snip}
quay.io/hmpps/hmpps-delius-interventions-event-listener (debian 11.1)
=====================================================================
Total: 6 (HIGH: 2, CRITICAL: 4)
{snip}
```

❗ This is **_not_** reported however, as our nightly trivy scan implement `--ignore-unfixed`, which is basically _hiding_ all of these, which to me feels wrong

This image has _no_ OS vulnerabilities and about half the size:
```
$ docker build . --tag=local.event-listener
{snip}

$ trivy image --severity HIGH,CRITICAL local.event-listener
local.event-listener (alpine 3.14.2)
====================================
Total: 0 (HIGH: 0, CRITICAL: 0)
```

It does _not_ fix the Java vulnerabilities flagged up by Trivy though