### PR TITLE
Process session feedback events (supplier assessment and service delivery)

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -14,7 +14,9 @@ generic-service:
     SERVICES_COMMUNITYAPI_BASEURL: https://community-api-secure.test.delius.probation.hmpps.dsd.io
     INTERVENTIONSUI_BASEURL: https://hmpps-interventions-ui-dev.apps.live-1.cloud-platform.service.justice.gov.uk
     LOGGING_LEVEL_UK_GOV_JUSTICE_DIGITAL_HMPPS_HMPPSDELIUSINTERVENTIONSEVENTLISTENER: debug
-    FEATURES_CRS_NOTIFYACTIONPLANSUBMITTED: true
+    FEATURES_CRS_NOTIFYACTIONPLANSUBMITTED: false
+    FEATURES_CRS_NOTIFYSUPPLIERASSESSMENTFEEDBACKSUBMITTED: true
+    FEATURES_CRS_NOTIFYDELIVERYSESSIONFEEDBACKSUBMITTED: true
 
   # use the same client credentials for community api and interventions api in dev
   namespace_secrets:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdeliusinterventionseventlistener/component/EventProcessor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdeliusinterventionseventlistener/component/EventProcessor.kt
@@ -5,12 +5,17 @@ import net.logstash.logback.argument.StructuredArguments.kv
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.InterventionsEvent
 import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.ActionPlan
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.DeliverySession
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.SupplierAssessment
 import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.service.CommunityApiService
 import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.service.InterventionsApiService
 import java.net.URI
+import java.util.UUID
 
 enum class EventType(val value: String) {
-  ACTION_PLAN_SUBMITTED("intervention.action-plan.submitted");
+  ACTION_PLAN_SUBMITTED("intervention.action-plan.submitted"),
+  DELIVERY_SESSION_FEEDBACK_SUBMITTED("intervention.session-appointment.session-feedback-submitted"),
+  SUPPLIER_ASSESSMENT_FEEDBACK_SUBMITTED("intervention.initial-assessment-appointment.session-feedback-submitted");
 
   companion object {
     private val map = values().associateBy { it.value }
@@ -33,6 +38,8 @@ class EventProcessor(
 
     when (eventType) {
       EventType.ACTION_PLAN_SUBMITTED -> processActionPlanSubmittedEvent(event)
+      EventType.SUPPLIER_ASSESSMENT_FEEDBACK_SUBMITTED -> processSupplierAssessmentFeedbackSubmittedEvent(event)
+      EventType.DELIVERY_SESSION_FEEDBACK_SUBMITTED -> processDeliverySessionFeedbackSubmittedEvent(event)
     }
   }
 
@@ -46,5 +53,31 @@ class EventProcessor(
 
     logger.debug("notifying nDelius of submitted action plan {} {} {}", kv("actionPlan", actionPlan), kv("referral", referral), kv("intervention", intervention))
     communityApiService.notifyActionPlanSubmitted(event.detailUrl, actionPlan, referral, intervention).block()
+  }
+
+  private fun processSupplierAssessmentFeedbackSubmittedEvent(event: InterventionsEvent) {
+    logger.debug("processing notify-supplier-assessment-feedback-submitted")
+    if (featureFlags.crs["notify-supplier-assessment-feedback-submitted"] != true) return
+
+    val supplierAssessment = interventionsApiService.get(URI(event.detailUrl), SupplierAssessment::class).block()
+    val deliusAppointmentId = event.get("deliusAppointmentId")
+    val referral = interventionsApiService.getReferral(UUID.fromString(event.get("referralId"))).block()
+    val intervention = interventionsApiService.getIntervention(referral.interventionId).block()
+
+    logger.debug("notifying nDelius of submitted supplier assessment feedback {} {} {}", kv("supplierAssessment", supplierAssessment), kv("referral", referral), kv("intervention", intervention))
+    communityApiService.notifySupplierAssessmentFeedbackSubmitted(event.detailUrl, supplierAssessment, deliusAppointmentId, referral, intervention).block()
+  }
+
+  private fun processDeliverySessionFeedbackSubmittedEvent(event: InterventionsEvent) {
+    logger.debug("processing notify-delivery-session-feedback-submitted")
+    if (featureFlags.crs["notify-delivery-session-feedback-submitted"] != true) return
+
+    val deliverySession = interventionsApiService.get(URI(event.detailUrl), DeliverySession::class).block()
+    val deliusAppointmentId = event.get("deliusAppointmentId")
+    val referral = interventionsApiService.getReferral(UUID.fromString(event.get("referralId"))).block()
+    val intervention = interventionsApiService.getIntervention(referral.interventionId).block()
+
+    logger.debug("notifying nDelius of submitted delivery session feedback {} {} {}", kv("deliverySession", deliverySession), kv("referral", referral), kv("intervention", intervention))
+    communityApiService.notifyDeliverySessionFeedbackSubmitted(event.detailUrl, deliverySession, deliusAppointmentId, referral, intervention).block()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdeliusinterventionseventlistener/model/InterventionsEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdeliusinterventionseventlistener/model/InterventionsEvent.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model
 
+import java.lang.IllegalStateException
 import java.time.OffsetDateTime
 
 data class InterventionsEvent(
@@ -9,4 +10,6 @@ data class InterventionsEvent(
   val detailUrl: String,
   val occurredAt: OffsetDateTime,
   val additionalInformation: Map<String, String>,
-)
+) {
+  fun get(name: String) = additionalInformation[name] ?: throw IllegalStateException("Missing additional information: $name")
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdeliusinterventionseventlistener/model/communityapi/AppointmentOutcomeRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdeliusinterventionseventlistener/model/communityapi/AppointmentOutcomeRequest.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.communityapi
+
+data class AppointmentOutcomeRequest(
+  val notes: String,
+  val attended: String,
+  val notifyPPOfAttendanceBehaviour: Boolean,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdeliusinterventionseventlistener/model/crs/Appointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdeliusinterventionseventlistener/model/crs/Appointment.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs
+
+import java.time.OffsetDateTime
+import java.util.UUID
+
+data class Appointment(
+  val id: UUID,
+  val appointmentTime: OffsetDateTime,
+  val durationInMinutes: Int,
+  val sessionFeedback: SessionFeedback,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdeliusinterventionseventlistener/model/crs/DeliverySession.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdeliusinterventionseventlistener/model/crs/DeliverySession.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs
+
+import java.time.OffsetDateTime
+import java.util.UUID
+
+data class DeliverySession(
+  val id: UUID,
+  val sessionNumber: Int,
+  val appointmentTime: OffsetDateTime,
+  val durationInMinutes: Int,
+  val sessionFeedback: SessionFeedback,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdeliusinterventionseventlistener/model/crs/SessionFeedback.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdeliusinterventionseventlistener/model/crs/SessionFeedback.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs
+
+data class SessionFeedback(
+  val attendance: Attendance,
+  val behaviour: Behaviour
+)
+
+data class Attendance(
+  val attended: String,
+)
+
+data class Behaviour(
+  val notifyProbationPractitioner: Boolean?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdeliusinterventionseventlistener/model/crs/SupplierAssessment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdeliusinterventionseventlistener/model/crs/SupplierAssessment.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs
+
+import java.util.UUID
+
+data class SupplierAssessment(
+  val id: UUID,
+  val appointments: List<Appointment>,
+  val currentAppointmentId: UUID,
+  val referralId: UUID,
+) {
+  val currentAppointment = appointments.find { it.id == currentAppointmentId }
+    ?: throw IllegalStateException("Supplier assessments contains no current appointment")
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdeliusinterventionseventlistener/service/CommunityApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsdeliusinterventionseventlistener/service/CommunityApiService.kt
@@ -6,28 +6,38 @@ import org.springframework.stereotype.Service
 import org.springframework.web.util.UriComponentsBuilder
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.component.CommunityApiClient
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.communityapi.AppointmentOutcomeRequest
 import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.communityapi.Contact
 import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.communityapi.CreateNotificationRequest
 import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.ActionPlan
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.DeliverySession
 import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.Intervention
 import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.SentReferral
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.SessionFeedback
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.SupplierAssessment
 import java.net.URI
 
 @Service
 class CommunityApiService(
   @Value("\${services.community-api.baseurl}") private val communityApiBaseURL: String,
   @Value("\${interventions-ui.baseurl}") private val interventionsUiBaseURL: String,
-  @Value("\${interventions-ui.locations.probation-practitioner.action-plan}") private val ppActionPlanLocation: String,
   private val communityApiClient: CommunityApiClient,
 ) {
   companion object : KLogging() {
     const val integrationContext = "commissioned-rehabilitation-services"
     const val communityApiNotificationRequestUrl = "/secure/offenders/crn/{crn}/sentences/{sentenceId}/notifications/context/{contextName}"
+    const val communityApiAppointmentOutcomeRequestUrl = "/secure/offenders/crn/{crn}/appointments/{appointmentId}/outcome/context/{contextName}"
+    const val ppActionPlanLocation = "/probation-practitioner/referrals/{id}/action-plan"
+    const val ppSupplierAssessmentFeedbackLocation = "/probation-practitioner/referrals/{id}/supplier-assessment/post-assessment-feedback"
+    const val ppDeliverySessionFeedbackLocation = "/probation-practitioner/referrals/{id}/appointment/{sessionNumber}/post-session-feedback"
   }
 
   fun notifyActionPlanSubmitted(detailUrl: String, actionPlan: ActionPlan, referral: SentReferral, intervention: Intervention): Mono<Contact> {
 
-    val backLinkUrl = buildBackLinkUrl(referral)
+    val backLinkUrl = UriComponentsBuilder.fromHttpUrl(interventionsUiBaseURL)
+      .path(ppActionPlanLocation)
+      .buildAndExpand(referral.id)
+      .toString()
 
     val body = CreateNotificationRequest(
       intervention.contractType.code,
@@ -52,11 +62,50 @@ class CommunityApiService(
     return communityApiClient.post(URI.create(communityApiUri), body, Contact::class)
   }
 
-  private fun buildBackLinkUrl(referral: SentReferral): String {
-    return UriComponentsBuilder.fromHttpUrl(interventionsUiBaseURL)
-      .path(ppActionPlanLocation)
+  fun notifySupplierAssessmentFeedbackSubmitted(detailUrl: String, supplierAssessment: SupplierAssessment, deliusAppointmentId: String, referral: SentReferral, intervention: Intervention): Mono<Contact> {
+
+    val backLinkUrl = UriComponentsBuilder.fromHttpUrl(interventionsUiBaseURL)
+      .path(ppSupplierAssessmentFeedbackLocation)
       .buildAndExpand(referral.id)
       .toString()
+
+    val sessionFeedback = supplierAssessment.currentAppointment.sessionFeedback
+    return notifyAppointmentFeedbackSubmitted(sessionFeedback, intervention, referral, backLinkUrl, deliusAppointmentId)
+  }
+
+  fun notifyDeliverySessionFeedbackSubmitted(detailUrl: String, deliverySession: DeliverySession, deliusAppointmentId: String, referral: SentReferral, intervention: Intervention): Mono<Contact> {
+
+    val backLinkUrl = UriComponentsBuilder.fromHttpUrl(interventionsUiBaseURL)
+      .path(ppDeliverySessionFeedbackLocation)
+      .buildAndExpand(referral.id, deliverySession.sessionNumber)
+      .toString()
+
+    val sessionFeedback = deliverySession.sessionFeedback
+    return notifyAppointmentFeedbackSubmitted(sessionFeedback, intervention, referral, backLinkUrl, deliusAppointmentId)
+  }
+
+  private fun notifyAppointmentFeedbackSubmitted(sessionFeedback: SessionFeedback, intervention: Intervention, referral: SentReferral, backLinkUrl: String, deliusAppointmentId: String): Mono<Contact> {
+    val notifyPP = setNotifyPPIfRequired(sessionFeedback)
+
+    val body = AppointmentOutcomeRequest(
+      buildNotesField(
+        intervention.contractType.name,
+        intervention.serviceProvider.name,
+        referral.referenceNumber,
+        backLinkUrl,
+        "Session Feedback Recorded"
+      ),
+      sessionFeedback.attendance.attended,
+      notifyPP
+    )
+
+    val communityApiUri = UriComponentsBuilder
+      .fromHttpUrl("$communityApiBaseURL$communityApiAppointmentOutcomeRequestUrl")
+      .buildAndExpand(referral.serviceUserCRN, deliusAppointmentId, integrationContext)
+      .toString()
+
+    logger.debug("Community-api request: $communityApiUri, payload: $body")
+    return communityApiClient.post(URI.create(communityApiUri), body, Contact::class)
   }
 
   private fun buildNotesField(
@@ -71,5 +120,11 @@ class CommunityApiService(
       $backLinkUrl
       (notified via delius-interventions-event-listener)
     """.trimIndent()
+  }
+
+  fun setNotifyPPIfRequired(sessionFeedback: SessionFeedback): Boolean {
+    val attendance = sessionFeedback.attendance
+    val behaviour = sessionFeedback.behaviour
+    return "no".equals(attendance.attended, true) || behaviour.notifyProbationPractitioner ?: false
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -73,9 +73,6 @@ services:
 # all features should be disabled by default and enabled per-environment
 features:
   crs:
-    notify-action-plan-submitted: false
-
-interventions-ui:
-  locations:
-    probation-practitioner:
-      action-plan: "/probation-practitioner/referrals/{id}/action-plan"
+    notify-action-plan-submitted: true
+    notify-supplier-assessment-feedback-submitted: true
+    notify-delivery-session-feedback-submitted: true

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdeliusinterventionseventlistener/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdeliusinterventionseventlistener/integration/IntegrationTestBase.kt
@@ -1,14 +1,22 @@
 package uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.integration
 
 import com.amazonaws.services.sqs.AmazonSQS
+import com.amazonaws.services.sqs.model.PurgeQueueRequest
 import org.awaitility.kotlin.await
 import org.awaitility.kotlin.matches
 import org.awaitility.kotlin.untilCallTo
+import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.reactive.server.WebTestClient
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.sns.SnsClient
+import java.net.URI
 
 @SpringBootTest(webEnvironment = RANDOM_PORT)
 @ActiveProfiles("local", "test")
@@ -17,6 +25,41 @@ abstract class IntegrationTestBase {
   @Suppress("SpringJavaInjectionPointsAutowiringInspection")
   @Autowired
   lateinit var webTestClient: WebTestClient
+
+  @Value("\${hmpps.sqs.queues.deliusinterventionseventsqueue.queueName}")
+  lateinit var interventionsEventQueue: String
+
+  @Value("\${hmpps.sqs.queues.deliusinterventionseventsqueue.dlqName}")
+  lateinit var interventionsEventDeadLetterQueue: String
+
+  @Value("\${hmpps.sqs.region}")
+  lateinit var region: String
+
+  @Value("\${hmpps.sqs.localstackUrl}")
+  lateinit var localStackUrl: String
+
+  @Autowired
+  @Qualifier("deliusinterventionseventsqueue-sqs-client")
+  lateinit var sqsClient: AmazonSQS
+
+  var snsClient: SnsClient? = null
+
+  var queueUrl: String? = null
+
+  var deadLetterQueueUrl: String? = null
+
+  @BeforeEach
+  fun beforeEach() {
+    snsClient = SnsClient.builder()
+      .region(Region.of(region))
+      .credentialsProvider { AwsBasicCredentials.create("test", "test") }
+      .endpointOverride(URI(localStackUrl))
+      .build()
+    queueUrl = sqsClient.getQueueUrl(interventionsEventQueue).queueUrl
+    sqsClient.purgeQueue(PurgeQueueRequest(queueUrl))
+    deadLetterQueueUrl = sqsClient.getQueueUrl(interventionsEventDeadLetterQueue).queueUrl
+    sqsClient.purgeQueue(PurgeQueueRequest(deadLetterQueueUrl))
+  }
 
   fun noMessagesCurrentlyOnQueue(client: AmazonSQS, queueUrl: String) {
     messagesCurrentlyOnQueue(client, queueUrl, 0)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdeliusinterventionseventlistener/integration/listener/SQSListenerSessionDeliveryOutcomeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdeliusinterventionseventlistener/integration/listener/SQSListenerSessionDeliveryOutcomeTest.kt
@@ -1,0 +1,166 @@
+package uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.integration.listener
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.mock.mockito.MockBean
+import reactor.core.publisher.Mono
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue
+import software.amazon.awssdk.services.sns.model.PublishRequest
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.component.CommunityApiClient
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.component.EventType.DELIVERY_SESSION_FEEDBACK_SUBMITTED
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.component.InterventionsApiClient
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.InterventionsEvent
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.communityapi.AppointmentOutcomeRequest
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.communityapi.Contact
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.Attendance
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.Behaviour
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.ContractType
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.DeliverySession
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.Intervention
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.SentReferral
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.ServiceProvider
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.SessionFeedback
+import java.net.URI
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class SQSListenerSessionDeliveryOutcomeTest : IntegrationTestBase() {
+
+  @Autowired
+  lateinit var objectMapper: ObjectMapper
+
+  @Value("\${hmpps.sqs.topics.interventioneventstopic.arn}")
+  lateinit var interventionsEventTopicArn: String
+
+  @MockBean
+  lateinit var interventionsApiClient: InterventionsApiClient
+
+  @MockBean
+  lateinit var communityApiClient: CommunityApiClient
+
+  @Test
+  fun `Message is consumed of queue bound to topic`() {
+
+    // Given
+    val serviceProvider = ServiceProvider("SP Name", "55555")
+    val intervention = Intervention(UUID.randomUUID(), "Title", "Desc", serviceProvider, ContractType("ACC", "Accommodation"))
+    val referral = SentReferral(UUID.randomUUID(), intervention.id, "CRN444", 123L, "ABCDEFGH", OffsetDateTime.now())
+    val sessionFeedback = SessionFeedback(Attendance("yes"), Behaviour(false))
+    val deliverySession = DeliverySession(UUID.randomUUID(), 1, OffsetDateTime.now(), 60, sessionFeedback)
+    val interventionsBaseUrl = "http://localhost:8080"
+
+    setUpDeliverySessionLookup(interventionsBaseUrl, referral.id, deliverySession)
+    setUpReferralLookup(interventionsBaseUrl, referral)
+    setUpInterventionsLookup(interventionsBaseUrl, intervention)
+
+    val communityApiBaseUrl = "http://localhost:8091"
+    val appointmentOutcomeRequestBody = buildAppointmentOutcomeRequest(intervention, referral, deliverySession.sessionNumber, sessionFeedback)
+    val deliusAppointmentId = "999"
+
+    setUpCommunityApiCall(communityApiBaseUrl, deliusAppointmentId, appointmentOutcomeRequestBody)
+
+    // When
+    val message = setUpSessionFeedbackSubmittedInterventionsMessage(interventionsBaseUrl, referral.id, deliverySession.sessionNumber, deliusAppointmentId)
+    snsClient!!.publish(message)
+
+    // Then
+    verifyCommunityApiCall(communityApiBaseUrl, deliusAppointmentId, appointmentOutcomeRequestBody)
+  }
+
+  @Test
+  fun `Message is placed in dead letter queue after successive failures`() {
+
+    // Given
+    val serviceProvider = ServiceProvider("SP Name", "55555")
+    val intervention = Intervention(UUID.randomUUID(), "Title", "Desc", serviceProvider, ContractType("ACC", "Accommodation"))
+    val referral = SentReferral(UUID.randomUUID(), intervention.id, "CRN444", 123L, "ABCDEFGH", OffsetDateTime.now())
+    val sessionFeedback = SessionFeedback(Attendance("yes"), Behaviour(false))
+    val deliverySession = DeliverySession(UUID.randomUUID(), 1, OffsetDateTime.now(), 60, sessionFeedback)
+    val interventionsBaseUrl = "http://localhost:8080"
+
+    setUpDeliverySessionLookupNotFound(interventionsBaseUrl, referral.id, deliverySession)
+    val deliusAppointmentId = "999"
+
+    // When
+    val message = setUpSessionFeedbackSubmittedInterventionsMessage(interventionsBaseUrl, referral.id, deliverySession.sessionNumber, deliusAppointmentId)
+    snsClient!!.publish(message)
+
+    // Then
+    verifyMessageOnDeadLetterQueueAfterFailure()
+  }
+
+  private fun verifyCommunityApiCall(communityApiBaseUrl: String, deliusAppointmentId: String, appointmentOutcomeRequest: AppointmentOutcomeRequest) {
+    noMessagesCurrentlyOnQueue(sqsClient, queueUrl!!)
+    noMessagesCurrentlyOnQueue(sqsClient, deadLetterQueueUrl!!)
+
+    verify(communityApiClient).post(
+      eq(URI.create("$communityApiBaseUrl/secure/offenders/crn/CRN444/appointments/$deliusAppointmentId/outcome/context/commissioned-rehabilitation-services")),
+      eq(appointmentOutcomeRequest),
+      eq(Contact::class)
+    )
+  }
+
+  private fun verifyMessageOnDeadLetterQueueAfterFailure() {
+    verifyZeroInteractions(communityApiClient)
+    noMessagesCurrentlyOnQueue(sqsClient, queueUrl!!)
+    oneMessageCurrentlyOnQueue(sqsClient, deadLetterQueueUrl!!)
+  }
+
+  private fun setUpDeliverySessionLookup(interventionsBaseUrl: String, referralId: UUID, deliverySession: DeliverySession) {
+    whenever(interventionsApiClient.get(eq(URI.create("$interventionsBaseUrl/sent-referral/$referralId/sessions/${deliverySession.sessionNumber}")), eq(DeliverySession::class))).thenReturn(Mono.just(deliverySession))
+  }
+
+  private fun setUpDeliverySessionLookupNotFound(interventionsBaseUrl: String, referralId: UUID, deliverySession: DeliverySession) {
+    whenever(interventionsApiClient.get(eq(URI.create("$interventionsBaseUrl/sent-referral/$referralId/sessions/${deliverySession.sessionNumber}")), eq(DeliverySession::class))).thenReturn(Mono.empty())
+  }
+
+  private fun setUpReferralLookup(interventionsBaseUrl: String, referral: SentReferral) {
+    whenever(interventionsApiClient.get(eq(URI.create("$interventionsBaseUrl/sent-referral/${referral.id}")), eq(SentReferral::class))).thenReturn(Mono.just(referral))
+  }
+
+  private fun setUpInterventionsLookup(interventionsBaseUrl: String, intervention: Intervention) {
+    whenever(interventionsApiClient.get(eq(URI.create("$interventionsBaseUrl/intervention/${intervention.id}")), eq(Intervention::class))).thenReturn(Mono.just(intervention))
+  }
+
+  private fun setUpCommunityApiCall(communityApiBaseUrl: String, deliusAppointmentId: String, appointmentOutcomeRequest: AppointmentOutcomeRequest) {
+    whenever(
+      communityApiClient.post(
+        eq(URI.create("$communityApiBaseUrl/secure/offenders/crn/CRN444/appointments/$deliusAppointmentId/outcome/context/commissioned-rehabilitation-services")),
+        eq(appointmentOutcomeRequest),
+        eq(Contact::class)
+      )
+    ).thenReturn(Mono.just(Contact(999L)))
+  }
+
+  private fun setUpSessionFeedbackSubmittedInterventionsMessage(interventionsBaseUrl: String, referralId: UUID, sessionNumber: Int, deliusAppointmentId: String): PublishRequest? {
+    val additionalInformation = mapOf("referralId" to referralId.toString(), "deliusAppointmentId" to deliusAppointmentId)
+    val event = InterventionsEvent(1, DELIVERY_SESSION_FEEDBACK_SUBMITTED.value, "Description", "$interventionsBaseUrl/sent-referral/$referralId/sessions/$sessionNumber", OffsetDateTime.now(), additionalInformation)
+    val messageAttributes = mapOf(
+      "eventType" to MessageAttributeValue.builder()
+        .dataType("String")
+        .stringValue(DELIVERY_SESSION_FEEDBACK_SUBMITTED.value)
+        .build()
+    )
+    return PublishRequest.builder()
+      .messageAttributes(messageAttributes)
+      .message(objectMapper.writeValueAsString(event))
+      .topicArn(interventionsEventTopicArn)
+      .build()
+  }
+
+  private fun buildAppointmentOutcomeRequest(intervention: Intervention, referral: SentReferral, sessionNumber: Int, sessionFeedback: SessionFeedback) =
+    AppointmentOutcomeRequest(
+      """Session Feedback Recorded for ${intervention.contractType.name} Referral ${referral.referenceNumber} with Prime Provider ${intervention.serviceProvider.name}
+http://localhost:3000/probation-practitioner/referrals/${referral.id}/appointment/$sessionNumber/post-session-feedback
+(notified via delius-interventions-event-listener)""",
+      sessionFeedback.attendance.attended,
+      sessionFeedback.behaviour.notifyProbationPractitioner!!
+    )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdeliusinterventionseventlistener/integration/listener/SQSListenerSupplierAssessmentOutcomeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdeliusinterventionseventlistener/integration/listener/SQSListenerSupplierAssessmentOutcomeTest.kt
@@ -1,0 +1,166 @@
+package uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.integration.listener
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.mock.mockito.MockBean
+import reactor.core.publisher.Mono
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue
+import software.amazon.awssdk.services.sns.model.PublishRequest
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.component.CommunityApiClient
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.component.EventType.SUPPLIER_ASSESSMENT_FEEDBACK_SUBMITTED
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.component.InterventionsApiClient
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.integration.IntegrationTestBase
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.InterventionsEvent
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.communityapi.AppointmentOutcomeRequest
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.communityapi.Contact
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.Appointment
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.Attendance
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.Behaviour
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.ContractType
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.Intervention
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.SentReferral
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.ServiceProvider
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.SessionFeedback
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.SupplierAssessment
+import java.net.URI
+import java.time.OffsetDateTime
+import java.util.UUID
+
+class SQSListenerSupplierAssessmentOutcomeTest : IntegrationTestBase() {
+
+  @Autowired
+  lateinit var objectMapper: ObjectMapper
+
+  @Value("\${hmpps.sqs.topics.interventioneventstopic.arn}")
+  lateinit var interventionsEventTopicArn: String
+
+  @MockBean
+  lateinit var interventionsApiClient: InterventionsApiClient
+
+  @MockBean
+  lateinit var communityApiClient: CommunityApiClient
+
+  @Test
+  fun `Message is consumed of queue bound to topic`() {
+
+    // Given
+    val serviceProvider = ServiceProvider("SP Name", "55555")
+    val intervention = Intervention(UUID.randomUUID(), "Title", "Desc", serviceProvider, ContractType("ACC", "Accommodation"))
+    val referral = SentReferral(UUID.randomUUID(), intervention.id, "CRN444", 123L, "ABCDEFGH", OffsetDateTime.now())
+    val sessionFeedback = SessionFeedback(Attendance("yes"), Behaviour(false))
+    val appointment = Appointment(UUID.randomUUID(), OffsetDateTime.now(), 60, sessionFeedback)
+    val supplierAssessment = SupplierAssessment(UUID.randomUUID(), listOf(appointment), appointment.id, referral.id)
+    val interventionsBaseUrl = "http://localhost:8080"
+
+    setUpSupplierAssessmentLookup(interventionsBaseUrl, referral.id, supplierAssessment)
+    setUpReferralLookup(interventionsBaseUrl, referral)
+    setUpInterventionsLookup(interventionsBaseUrl, intervention)
+
+    val communityApiBaseUrl = "http://localhost:8091"
+    val appointmentOutcomeRequestBody = buildAppointmentOutcomeRequest(intervention, referral, sessionFeedback)
+    val deliusAppointmentId = "999"
+
+    setUpCommunityApiCall(communityApiBaseUrl, deliusAppointmentId, appointmentOutcomeRequestBody)
+
+    // When
+    val message = setUpSessionFeedbackSubmittedInterventionsMessage(interventionsBaseUrl, referral.id, deliusAppointmentId)
+    snsClient!!.publish(message)
+
+    // Then
+    verifyCommunityApiCall(communityApiBaseUrl, deliusAppointmentId, appointmentOutcomeRequestBody)
+  }
+
+  @Test
+  fun `Message is placed in dead letter queue after successive failures`() {
+
+    // Given
+    val serviceProvider = ServiceProvider("SP Name", "55555")
+    val intervention = Intervention(UUID.randomUUID(), "Title", "Desc", serviceProvider, ContractType("ACC", "Accommodation"))
+    val referral = SentReferral(UUID.randomUUID(), intervention.id, "CRN444", 123L, "ABCDEFGH", OffsetDateTime.now())
+    val interventionsBaseUrl = "http://localhost:8080"
+
+    setUpSupplierAssessmentLookupNotFound(interventionsBaseUrl, referral.id)
+    val deliusAppointmentId = "999"
+
+    // When
+    val message = setUpSessionFeedbackSubmittedInterventionsMessage(interventionsBaseUrl, referral.id, deliusAppointmentId)
+    snsClient!!.publish(message)
+
+    // Then
+    verifyMessageOnDeadLetterQueueAfterFailure()
+  }
+
+  private fun verifyCommunityApiCall(communityApiBaseUrl: String, deliusAppointmentId: String, appointmentOutcomeRequest: AppointmentOutcomeRequest) {
+    noMessagesCurrentlyOnQueue(sqsClient, queueUrl!!)
+    noMessagesCurrentlyOnQueue(sqsClient, deadLetterQueueUrl!!)
+
+    verify(communityApiClient).post(
+      eq(URI.create("$communityApiBaseUrl/secure/offenders/crn/CRN444/appointments/$deliusAppointmentId/outcome/context/commissioned-rehabilitation-services")),
+      eq(appointmentOutcomeRequest),
+      eq(Contact::class)
+    )
+  }
+
+  private fun verifyMessageOnDeadLetterQueueAfterFailure() {
+    verifyZeroInteractions(communityApiClient)
+    noMessagesCurrentlyOnQueue(sqsClient, queueUrl!!)
+    oneMessageCurrentlyOnQueue(sqsClient, deadLetterQueueUrl!!)
+  }
+
+  private fun setUpSupplierAssessmentLookup(interventionsBaseUrl: String, referralId: UUID, supplierAssessment: SupplierAssessment) {
+    whenever(interventionsApiClient.get(eq(URI.create("$interventionsBaseUrl/sent-referral/$referralId/supplier-assessment")), eq(SupplierAssessment::class))).thenReturn(Mono.just(supplierAssessment))
+  }
+
+  private fun setUpSupplierAssessmentLookupNotFound(interventionsBaseUrl: String, referralId: UUID) {
+    whenever(interventionsApiClient.get(eq(URI.create("$interventionsBaseUrl/sent-referral/$referralId/supplier-assessment")), eq(SupplierAssessment::class))).thenReturn(Mono.empty())
+  }
+
+  private fun setUpReferralLookup(interventionsBaseUrl: String, referral: SentReferral) {
+    whenever(interventionsApiClient.get(eq(URI.create("$interventionsBaseUrl/sent-referral/${referral.id}")), eq(SentReferral::class))).thenReturn(Mono.just(referral))
+  }
+
+  private fun setUpInterventionsLookup(interventionsBaseUrl: String, intervention: Intervention) {
+    whenever(interventionsApiClient.get(eq(URI.create("$interventionsBaseUrl/intervention/${intervention.id}")), eq(Intervention::class))).thenReturn(Mono.just(intervention))
+  }
+
+  private fun setUpCommunityApiCall(communityApiBaseUrl: String, deliusAppointmentId: String, appointmentOutcomeRequest: AppointmentOutcomeRequest) {
+    whenever(
+      communityApiClient.post(
+        eq(URI.create("$communityApiBaseUrl/secure/offenders/crn/CRN444/appointments/$deliusAppointmentId/outcome/context/commissioned-rehabilitation-services")),
+        eq(appointmentOutcomeRequest),
+        eq(Contact::class)
+      )
+    ).thenReturn(Mono.just(Contact(999L)))
+  }
+
+  private fun setUpSessionFeedbackSubmittedInterventionsMessage(interventionsBaseUrl: String, referralId: UUID, deliusAppointmentId: String): PublishRequest? {
+    val additionalInformation = mapOf("referralId" to referralId.toString(), "deliusAppointmentId" to deliusAppointmentId)
+    val event = InterventionsEvent(1, SUPPLIER_ASSESSMENT_FEEDBACK_SUBMITTED.value, "Description", "$interventionsBaseUrl/sent-referral/$referralId/supplier-assessment", OffsetDateTime.now(), additionalInformation)
+    val messageAttributes = mapOf(
+      "eventType" to MessageAttributeValue.builder()
+        .dataType("String")
+        .stringValue(SUPPLIER_ASSESSMENT_FEEDBACK_SUBMITTED.value)
+        .build()
+    )
+    return PublishRequest.builder()
+      .messageAttributes(messageAttributes)
+      .message(objectMapper.writeValueAsString(event))
+      .topicArn(interventionsEventTopicArn)
+      .build()
+  }
+
+  private fun buildAppointmentOutcomeRequest(intervention: Intervention, referral: SentReferral, sessionFeedback: SessionFeedback) =
+    AppointmentOutcomeRequest(
+      """Session Feedback Recorded for ${intervention.contractType.name} Referral ${referral.referenceNumber} with Prime Provider ${intervention.serviceProvider.name}
+http://localhost:3000/probation-practitioner/referrals/${referral.id}/supplier-assessment/post-assessment-feedback
+(notified via delius-interventions-event-listener)""",
+      sessionFeedback.attendance.attended,
+      sessionFeedback.behaviour.notifyProbationPractitioner!!
+    )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdeliusinterventionseventlistener/service/CommunityApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsdeliusinterventionseventlistener/service/CommunityApiServiceTest.kt
@@ -1,0 +1,51 @@
+package uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.service
+
+import com.nhaarman.mockitokotlin2.mock
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.component.CommunityApiClient
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.Attendance
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.Behaviour
+import uk.gov.justice.digital.hmpps.hmppsdeliusinterventionseventlistener.model.crs.SessionFeedback
+
+internal class CommunityApiServiceTest {
+
+  private val communityApiClient = mock<CommunityApiClient>()
+
+  private val communityApiService = CommunityApiService(
+    "services.community-api.baseurl",
+    "interventions-ui.baseurl",
+    communityApiClient,
+  )
+
+  @Test
+  fun `sets notify PP when non attendance or behaviour notified`() {
+    assertTrue(communityApiService.setNotifyPPIfRequired(SessionFeedback(Attendance("no"), Behaviour(null))))
+    assertTrue(communityApiService.setNotifyPPIfRequired(SessionFeedback(Attendance("yes"), Behaviour(true))))
+    assertTrue(communityApiService.setNotifyPPIfRequired(SessionFeedback(Attendance("late"), Behaviour(true))))
+
+    assertTrue(communityApiService.setNotifyPPIfRequired(SessionFeedback(Attendance("No"), Behaviour(null))))
+    assertTrue(communityApiService.setNotifyPPIfRequired(SessionFeedback(Attendance("YES"), Behaviour(true))))
+    assertTrue(communityApiService.setNotifyPPIfRequired(SessionFeedback(Attendance("lAtE"), Behaviour(true))))
+  }
+
+  @Test
+  fun `sets notify PP to false when no attendance nor behaviour issues`() {
+    assertFalse(communityApiService.setNotifyPPIfRequired(SessionFeedback(Attendance("yes"), Behaviour(false))))
+    assertFalse(communityApiService.setNotifyPPIfRequired(SessionFeedback(Attendance("late"), Behaviour(false))))
+    assertFalse(communityApiService.setNotifyPPIfRequired(SessionFeedback(Attendance("yes"), Behaviour(null))))
+    assertFalse(communityApiService.setNotifyPPIfRequired(SessionFeedback(Attendance("late"), Behaviour(null))))
+
+    assertFalse(communityApiService.setNotifyPPIfRequired(SessionFeedback(Attendance("YES"), Behaviour(false))))
+    assertFalse(communityApiService.setNotifyPPIfRequired(SessionFeedback(Attendance("Late"), Behaviour(false))))
+    assertFalse(communityApiService.setNotifyPPIfRequired(SessionFeedback(Attendance("yeS"), Behaviour(null))))
+    assertFalse(communityApiService.setNotifyPPIfRequired(SessionFeedback(Attendance("aAtE"), Behaviour(null))))
+  }
+
+  @Test
+  fun `behaviour not relevant (and hence ignored) if non attendance`() {
+    assertTrue(communityApiService.setNotifyPPIfRequired(SessionFeedback(Attendance("no"), Behaviour(true))))
+    assertTrue(communityApiService.setNotifyPPIfRequired(SessionFeedback(Attendance("no"), Behaviour(false))))
+  }
+}


### PR DESCRIPTION
https://trello.com/c/xHVqOzpw/155-notify-appointment-outcome-via-event-listener

**What does this pull request do?**
Event processor extended to now process the two event types which call community-api to affect the change in delius
1. intervention.session-appointment.session-feedback-submitted
2. intervention.initial-assessment-appointment.session-feedback-submitted

**What is the intent behind these changes?**
The intent is to route more interventions events via the event-listener rather than interventions calling community-api. This is to reduce the coupling between the systems and thus deal with outages that may arise in community-api/delius
