### PR TITLE
Corrected reported vulnerabilities CVEs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,8 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
+  // Issue with 4.1.67.Final from spring-boot-starter-webflux
+  implementation("io.netty:netty-codec:4.1.70.Final")
 
   // aws
   implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:1.0.3")
@@ -17,12 +19,6 @@ dependencies {
   implementation("io.github.microutils:kotlin-logging-jvm:2.1.0")
 
   testImplementation("org.awaitility:awaitility-kotlin:4.1.1")
-}
-
-dependencyManagement {
-  imports {
-    mavenBom("io.awspring.cloud:spring-cloud-aws-messaging:2.3.2")
-  }
 }
 
 configurations {


### PR DESCRIPTION
Corrected vulnerabilities stated here:

https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-delius-interventions-event-listener/184/workflows/da8f0134-395d-4d64-81f5-6a426e6d8846/jobs/518

implementation("io.netty:netty-codec:4.1.70.Final") as per interventions-service fixes netty-codec issue
import mavenBom("io.awspring.cloud:spring-cloud-aws-messaging:2.3.2") removal fixes transient dependency on old version of springframework - this import doesn't seem to be required
