### PR TITLE
Verify container image and security on every build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,30 +43,39 @@ workflows:
   version: 2
   build-test-and-deploy:
     jobs:
-      - validate:
-          filters:
-            tags:
-              ignore: /.*/
+      - validate
       - hmpps/helm_lint:
           name: helm_lint
       - hmpps/build_docker:
-          name: build_docker
+          name: build_docker_branch
+          publish: false
+          persist_container_image: true
           filters:
             branches:
-              only:
-                - main
+              ignore: [main]
+      - hmpps/build_docker:
+          name: build_docker_main
+          publish: true
+          persist_container_image: true
+          filters:
+            branches:
+              only: [main]
+      - hmpps/trivy_pipeline_scan:
+          name: trivy_scan
+          requires: [build_docker_branch, build_docker_main]
       - hmpps/deploy_env:
           name: deploy_dev
           env: "dev"
           context: hmpps-common-vars
           filters:
             branches:
-              only:
-                - main
+              only: [main]
           requires:
             - validate
-            - build_docker
+            - build_docker_branch
+            - build_docker_main
             - helm_lint
+            - trivy_scan
       - request-preprod-approval:
           type: approval
           requires:


### PR DESCRIPTION
## What does this pull request do?

Verify container image and security on every build

## Why?

Intent: shorten feedback loop, increase visibility

Otherwise, we could introduce Docker build failures or critical security
problems in builds which we would only notice at `main` build or the
`nightly` build