### PR TITLE
Route alerts to #interventions-dev-notifications

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -25,7 +25,5 @@ generic-service:
       SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_INTERVENTIONSEVENTCLIENT_CLIENTID: interventions-event-client-id.txt
       SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_INTERVENTIONSEVENTCLIENT_CLIENTSECRET: interventions-event-client-secret.txt
 
-# CloudPlatform AlertManager receiver to route promethues alerts to slack
-# See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
-# generic-prometheus-alerts:
-#   alertSeverity: hmpps-delius-interventions-event-listener-dev
+  generic-prometheus-alerts:
+    alertSeverity: hmpps-interventions-non-prod

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -24,3 +24,6 @@ generic-service:
       # the client that connects to interventions-service and community-api
       SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_INTERVENTIONSEVENTCLIENT_CLIENTID: interventions-event-client-id.txt
       SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_INTERVENTIONSEVENTCLIENT_CLIENTSECRET: interventions-event-client-secret.txt
+
+  generic-prometheus-alerts:
+    alertSeverity: hmpps-interventions-non-prod


### PR DESCRIPTION
`hmpps-interventions-non-prod` severity routes to `#interventions-dev-notifications` (set up via https://github.com/ministryofjustice/cloud-platform-infrastructure/pull/1212#issuecomment-856001663)

This is to relieve `#dps_alerts_non_prod` from our messages