### PR TITLE
Deploy to pre-prod after successful dev deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,10 +80,6 @@ workflows:
             - build_docker_main
             - helm_lint
             - trivy_scan
-      - request-preprod-approval:
-          type: approval
-          requires:
-            - deploy_dev
       - hmpps/deploy_env:
           name: deploy_preprod
           env: "preprod"
@@ -93,7 +89,7 @@ workflows:
             - hmpps-common-vars
             - hmpps-interventions-preprod-deploy
           requires:
-            - request-preprod-approval
+            - deploy_dev
 #      - request-prod-approval:
 #          type: approval
 #          requires:


### PR DESCRIPTION

## What does this pull request do?

In other words, remove the manual approval to pre-prod.

Similar to
- https://github.com/ministryofjustice/hmpps-interventions-service/pull/714

## What is the intent behind these changes?

As the majority of our changes (99%+) are correct and safe, there is no reason to hold back. My hypothesis is that if we get the changes to a live-like environment sooner, we will be aware of data problems/migration problems sooner.
