### PR TITLE
Bump log4j-to-slf4j adapter to 2.16.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,8 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
   // bumps for security, until bumped in upstream
   implementation("io.netty:netty-codec:4.1.72.Final")
-  implementation("org.apache.logging.log4j:log4j-api:2.15.0")
+  implementation("org.apache.logging.log4j:log4j-api:2.16.0") // CVE-2021-44228
+  implementation("org.apache.logging.log4j:log4j-to-slf4j:2.16.0") // CVE-2021-44228
 
   // aws
   implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:1.0.3")


### PR DESCRIPTION
Raised by nightly `./gradlew dependencyCheckAnalyze`

https://715-404359089-gh.circle-artifacts.com/0/Reports/OWASP/dependency-check-report.html