### PR TITLE
Change code owners to the agreed dev team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ministryofjustice/interventions-service
+* @ministryofjustice/hmpps-interventions-dev


### PR DESCRIPTION

## What does this pull request do?

Change code owners to the agreed dev team

## What is the intent behind these changes?

We agreed on 26 November 2021 that we would simplify the teams in GitHub
by creating a new dev-only team to access:

- code and reviews on all apps
- repository admin
- CI/CD pipelines
- security tooling
- access to non-prod environments
- access to prod environments

As this simplifies our authorization model
