### PR TITLE
Mitigate CVE-2022-23181

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,12 +8,6 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
-  // bumps for security, until bumped in upstream
-  implementation("io.netty:netty-codec:4.1.73.Final")
-  implementation("ch.qos.logback:logback-classic:1.2.10") // CVE-2021-42550
-  implementation("ch.qos.logback:logback-core:1.2.10") // CVE-2021-42550
-  implementation("org.apache.logging.log4j:log4j-api:2.17.1") // CVE-2021-44228
-  implementation("org.apache.logging.log4j:log4j-to-slf4j:2.17.1") // CVE-2021-44228
 
   // aws
   implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:1.0.5")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,9 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
+  // bumps for security, until bumped in upstream
+  implementation("org.apache.tomcat.embed:tomcat-embed-core:9.0.58") // CVE-2022-23181
+  implementation("org.apache.tomcat.embed:tomcat-embed-websocket:9.0.58") // CVE-2022-23181
 
   // aws
   implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:1.0.5")


### PR DESCRIPTION
## What does this pull request do?

- Mitigate CVE-2022-23181
- Remove unnecessarily pinned dependencies (cleanup)

## What is the intent behind these changes?

Reduce vulnerabilities; this has been flagged by `./gradlew dependencyCheckAnalyze --info`