### PR TITLE
Unblock message-related tests failing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
       tag: "16.0"
     docker:
       - image: cimg/openjdk:16.0
-      - image: localstack/localstack:latest
+      - image: localstack/localstack:0.14.2
         environment:
           SERVICES: sns,sqs
           DEFAULT_REGION: eu-west-2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.1.6"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.2.1"
   kotlin("plugin.spring") version "1.6.21"
 }
 
@@ -11,11 +11,11 @@ dependencies {
 
   // aws
   implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:1.1.3")
-  implementation("software.amazon.awssdk:sns:2.17.16")
+  implementation("software.amazon.awssdk:sns:2.17.205")
 
   // monitoring & logging
-  implementation("io.github.microutils:kotlin-logging-jvm:2.1.21")
-  implementation("net.logstash.logback:logstash-logback-encoder:7.1.1")
+  implementation("io.github.microutils:kotlin-logging-jvm:2.1.23")
+  implementation("net.logstash.logback:logstash-logback-encoder:7.2")
 
   testImplementation("org.awaitility:awaitility-kotlin:4.2.0")
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
   localstack:
     container_name: "${LOCALSTACK_DOCKER_NAME-localstack_main}"
-    image: localstack/localstack
+    image: localstack/localstack:0.14.2
     network_mode: bridge
     ports:
       - "4566:4566"


### PR DESCRIPTION
The cause seems to be `localstack/localstack:0.14.3`; so for now, this
pins the version of localstack to 0.14.2 until we can figure out why it
broke

This unblocks the CI pipeline for the other changes